### PR TITLE
Swap mutation

### DIFF
--- a/src/mutation.py
+++ b/src/mutation.py
@@ -25,10 +25,29 @@ def inversion_mutation(parent: list, start_index: int, end_index: int) -> list:
     :param start_index: Starting index of the inversion mutation
     :param end_index: Ending index of the inversion mutation (excluded in reversal)
     :return: The chromosome after the mutation is applied
+    :raises ValueError: If either index is out-of-bounds
     """
     if start_index < 0 or end_index < 0 or start_index > len(parent) or end_index > len(parent):
         raise ValueError(f"Index out-of-bounds: {start_index}, {end_index}")
 
     child = parent[:]
     child[start_index:end_index] = child[start_index:end_index][::-1]
+    return child
+
+
+def swap_mutation(parent:list, index_1: int, index_2: int) -> list:
+    """
+    Swap mutation. Swap the values between the two specified indices. For example, with swap indices of 0 and 3,
+    [0, 1, 2, 3, 4] -> [3, 1, 2, 0, 4]. Providing the same index for both index values results in no change.
+
+    :param parent: Chromosome to be mutated
+    :param index_1: Index to be swapped with index_2
+    :param index_2: Index to be swapped with index_1
+    :return: The chromosome after the mutation is applied
+    :raises ValueError: If either index is out-of-bounds
+    """
+    if index_1 < 0 or index_2 < 0 or index_1 > len(parent) - 1 or index_2 > len(parent) - 1:
+        raise ValueError(f"Index out-of-bounds: {index_1}, {index_2}")
+    child = parent[:]
+    child[index_1], child[index_2] = child[index_2], child[index_1]
     return child

--- a/src/mutation.py
+++ b/src/mutation.py
@@ -35,7 +35,7 @@ def inversion_mutation(parent: list, start_index: int, end_index: int) -> list:
     return child
 
 
-def swap_mutation(parent:list, index_1: int, index_2: int) -> list:
+def swap_mutation(parent: list, index_1: int, index_2: int) -> list:
     """
     Swap mutation. Swap the values between the two specified indices. For example, with swap indices of 0 and 3,
     [0, 1, 2, 3, 4] -> [3, 1, 2, 0, 4]. Providing the same index for both index values results in no change.

--- a/test/test_mutation.py
+++ b/test/test_mutation.py
@@ -36,37 +36,25 @@ class TestMutation(unittest.TestCase):
     def test_inversion_mutation_same_indices_returns_unchanged_chromosome(self):
         chromosome = [0, 1, 2, 3, 4]
         indices = [(0, 0), (1, 1), (5, 5)]
-        expected_chromosomes = [
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-        ]
-        for index, expected_chromosome in zip(indices, expected_chromosomes):
-            with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
+        expected_chromosome = [0, 1, 2, 3, 4]
+        for index in indices:
+            with self.subTest(start=index[0], end=index[1]):
                 self.assertEqual(expected_chromosome, inversion_mutation(chromosome, index[0], index[1]))
 
     def test_inversion_mutation_adjacent_indices_returns_unchanged_chromosome(self):
         chromosome = [0, 1, 2, 3, 4]
         indices = [(0, 1), (1, 2), (4, 5)]
-        expected_chromosomes = [
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-        ]
-        for index, expected_chromosome in zip(indices, expected_chromosomes):
-            with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
+        expected_chromosome = [0, 1, 2, 3, 4]
+        for index in indices:
+            with self.subTest(start=index[0], end=index[1]):
                 self.assertEqual(expected_chromosome, inversion_mutation(chromosome, index[0], index[1]))
 
     def test_inversion_mutation_high_index_before_low_returns_unchanged_chromosome(self):
         chromosome = [0, 1, 2, 3, 4]
         indices = [(1, 0), (4, 2), (5, 0)]
-        expected_chromosomes = [
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-        ]
-        for index, expected_chromosome in zip(indices, expected_chromosomes):
-            with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
+        expected_chromosome = [0, 1, 2, 3, 4]
+        for index in indices:
+            with self.subTest(start=index[0], end=index[1]):
                 self.assertEqual(expected_chromosome, inversion_mutation(chromosome, index[0], index[1]))
 
     def test_inversion_mutation_indices_out_of_bounds_raises_value_error(self):
@@ -88,13 +76,9 @@ class TestMutation(unittest.TestCase):
     def test_swap_mutation_same_indices_returns_unchanged_chromosome(self):
         chromosome = [0, 1, 2, 3, 4]
         indices = [(0, 0), (1, 1), (4, 4)]
-        expected_chromosomes = [
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-            [0, 1, 2, 3, 4],
-        ]
-        for index, expected_chromosome in zip(indices, expected_chromosomes):
-            with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
+        expected_chromosome = [0, 1, 2, 3, 4]
+        for index in indices:
+            with self.subTest(start=index[0], end=index[1]):
                 self.assertEqual(expected_chromosome, swap_mutation(chromosome, index[0], index[1]))
 
     def test_swap_mutation_indices_out_of_bounds_raises_value_error(self):

--- a/test/test_mutation.py
+++ b/test/test_mutation.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.mutation import bit_flip_mutation, inversion_mutation
+from src.mutation import bit_flip_mutation, inversion_mutation, swap_mutation
 
 
 class TestMutation(unittest.TestCase):
@@ -57,7 +57,7 @@ class TestMutation(unittest.TestCase):
             with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
                 self.assertEqual(expected_chromosome, inversion_mutation(chromosome, index[0], index[1]))
 
-    def test_inversion_mutation_high_index_before_low_returns_changed_chromosome(self):
+    def test_inversion_mutation_high_index_before_low_returns_unchanged_chromosome(self):
         chromosome = [0, 1, 2, 3, 4]
         indices = [(1, 0), (4, 2), (5, 0)]
         expected_chromosomes = [
@@ -76,3 +76,31 @@ class TestMutation(unittest.TestCase):
             with self.subTest(start=index[0], end=index[1]):
                 with self.assertRaises(ValueError):
                     inversion_mutation(chromosome, index[0], index[1])
+
+    def test_swap_mutation_valid_case_returns_changed_chromosome(self):
+        chromosome = [0, 1, 2, 3, 4]
+        indices = [(0, 2), (0, 3), (1, 4), (2, 4)]
+        expected_chromosomes = [[2, 1, 0, 3, 4], [3, 1, 2, 0, 4], [0, 4, 2, 3, 1], [0, 1, 4, 3, 2]]
+        for index, expected_chromosome in zip(indices, expected_chromosomes):
+            with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
+                self.assertEqual(expected_chromosome, swap_mutation(chromosome, index[0], index[1]))
+
+    def test_swap_mutation_same_indices_returns_unchanged_chromosome(self):
+        chromosome = [0, 1, 2, 3, 4]
+        indices = [(0, 0), (1, 1), (4, 4)]
+        expected_chromosomes = [
+            [0, 1, 2, 3, 4],
+            [0, 1, 2, 3, 4],
+            [0, 1, 2, 3, 4],
+        ]
+        for index, expected_chromosome in zip(indices, expected_chromosomes):
+            with self.subTest(start=index[0], end=index[1], expected_chromosome=expected_chromosome):
+                self.assertEqual(expected_chromosome, swap_mutation(chromosome, index[0], index[1]))
+
+    def test_swap_mutation_indices_out_of_bounds_raises_value_error(self):
+        chromosome = [0, 0, 0, 0, 0]
+        bad_indices = [(-1, 3), (3, -101), (3, 5), (101, 3), (-1, -1), (5, 5)]
+        for index in bad_indices:
+            with self.subTest(start=index[0], end=index[1]):
+                with self.assertRaises(ValueError):
+                    swap_mutation(chromosome, index[0], index[1])


### PR DESCRIPTION

### What

Swap mutation

Also snuck in a `:raise:` in inversion's docstring. 