### PR TITLE
💄 2.5.1 CROSSOVER_RATE math notation update

### DIFF
--- a/site/topics/genetic-algorithms/simple-ga.rst
+++ b/site/topics/genetic-algorithms/simple-ga.rst
@@ -250,7 +250,7 @@ Crossover
 * Thus, this provides a way for selected candidate solutions to persist in the next generation unchanged
 * The probability of crossover being applied is defined by a hyperparameter called ``CROSSOVER_RATE``
 
-    * Value would be between :math:`0 -- 1`
+    * Value would be ``0 <= CROSSOVER_RATE <= 1``
 
 
 Potential Problem


### PR DESCRIPTION
:lipstick:
### What
Swapped "0 -- 1" to "0 <= CROSSOVER_RATE <= 1"

### Why
Tbh unsure what "0 -- 1" meant and thought it could be a typo, if it's 
math notation then I've got studying to do. Changed it to what I did to really drive the point home