### PR TITLE
:technologist: Unit tests --- Fix class names so they match :microscope: 

### DIFF
--- a/test/test_ga_n_queens.py
+++ b/test/test_ga_n_queens.py
@@ -3,7 +3,7 @@ import unittest
 from src.ga_n_queens import attacking_fitness
 
 
-class TestGAMaxBitstring(unittest.TestCase):
+class TestGANQueens(unittest.TestCase):
     def test_attacking_fitness_various_cases_returns_correct_fitness(self):
         chromosomes = [
             [0],

--- a/test/test_pso.py
+++ b/test/test_pso.py
@@ -3,7 +3,7 @@ import unittest
 from src.pso import matyas_function
 
 
-class TestGAMaxBitstring(unittest.TestCase):
+class TestPso(unittest.TestCase):
     def test_matyas_function_returns_correct_value(self):
         vectors = [(0, 0), (1, 1), (1, 2), (-5, 5), (10, 10), (-100, 100)]
         expecteds = [0, 0.04, 0.34, 25, 4, 10000]


### PR DESCRIPTION
### What

Rename the test classes for PSO and the n queens GA. 

### Why

They were named wrong as a result of a lazy copy/paste. 

### Testing

:+1: