### PR TITLE
:lipstick: Topic selection --- Mention selection pressure :microscope: 

### DIFF
--- a/site/topics/selection/selection.rst
+++ b/site/topics/selection/selection.rst
@@ -107,6 +107,7 @@ Tournament Selection
 
     * If :math:`k = 1`, this would be the same as a uniform selection
     * If :math:`k = \mu`, this would be the same as always selecting the best
+    * As :math:`k` increases, so does the selection pressure
 
 
 

--- a/site/topics/selection/selection.rst
+++ b/site/topics/selection/selection.rst
@@ -77,11 +77,13 @@ Tournament Selection
     * However, in general, it's not going to perform well as there is nothing guiding the search
 
         * The algorithm will not converge
+        * There is low *selection pressure*
 
 
 #. Select the top chromosomes only and apply the genetic operators
 
     * As already seen, this will not perform well as the population will converge too quickly on some local optimum
+    * There is high *selection pressure*
 
 
 * An alternative highly effective selection is to go somewhere in between these ideas


### PR DESCRIPTION
### What

Mention selection pressure

### Why

I removed the section on selection pressure since it's already been used as a word a bunch in the course and there really wasn't much to talk about in the section. Some nerds came up with a formula for selection pressure that is kinda' BS and something no one really uses anyways. I _was_ going to go into this, but nah, it's dumb. 

Because I _was_ going to have a section, I deliberately didn't use the phrase in this topic

Now that the section is gone, I can use the words I always wanted to. 
