### PR TITLE
:mortar_board: Topic genetic programming --- Add to index :microscope: 

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -60,6 +60,7 @@ YouTube
     topics/genetic-algorithms/n-queens-ga-experiment
     topics/genetic-operators/genetic-operators
     topics/selection/selection
+    topics/genetic-programming/genetic-programming
 
 
 .. toctree::

--- a/site/topics/genetic-programming/genetic-programming.rst
+++ b/site/topics/genetic-programming/genetic-programming.rst
@@ -345,16 +345,6 @@ Bloat
 
 
 
-Example Problem --- Symbolic Regression
-=======================================
-
-
-
-Interesting Applications
-========================
-
-
-
 For Next Class
 ==============
 


### PR DESCRIPTION
### What

1. Add page to index
2. Remove last 2 sections from the GP topic

### Why

1. So they can get there
2. The whole next topic will be a symbolic regression example and the "cool applications" is dumb. 


### Testing

:+1: and it was good, except it's still doing that weird thing where it does not add to index right when built local. :shrug: 