### PR TITLE
:technologist: :bug: GP code --- Use tournament constant :microscope: 

### DIFF
--- a/src/gp_symbolic_regression.py
+++ b/src/gp_symbolic_regression.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
         independent_variables=independent_variables,
         dependent_variable=dependent_variable,
     )
-    toolbox.register("select", tools.selTournament, tournsize=2)
+    toolbox.register("select", tools.selTournament, tournsize=TOURNAMENT_SIZE)
     toolbox.register("mate", gp.cxOnePoint)
     toolbox.register("generate_mutation_subtree", gp.genFull, min_=0, max_=4)
     toolbox.register("mutate", gp.mutUniform, expr=toolbox.generate_mutation_subtree, pset=primitive_set)


### PR DESCRIPTION
### What

Replace the literal `2` for the "constant" `TOURNAMENT_SIZE`

### Why

Should have been used in the first place. It was a bug. 

### Testing

YOLO
