### PR TITLE
:technologist: :lipstick: Symbolic regression --- Make bloat control hyperparams :microscope: 

### DIFF
--- a/src/gp_symbolic_regression.py
+++ b/src/gp_symbolic_regression.py
@@ -20,6 +20,8 @@ GENERATIONS = 100
 TOURNAMENT_SIZE = 2
 CROSSOVER_RATE = 0.80
 MUTATION_RATE = 0.05
+MAX_HEIGHT = 6
+MAX_NODES = 32
 # [end-hyperparameters]
 
 # [begin-data-parameters]
@@ -131,10 +133,10 @@ if __name__ == "__main__":
     # [end-setting-hyperparameters]
 
     # [begin-bloat-control]
-    toolbox.decorate("mate", gp.staticLimit(key=operator.attrgetter("height"), max_value=6))
-    toolbox.decorate("mutate", gp.staticLimit(key=operator.attrgetter("height"), max_value=6))
-    toolbox.decorate("mate", gp.staticLimit(key=len, max_value=32))
-    toolbox.decorate("mutate", gp.staticLimit(key=len, max_value=32))
+    toolbox.decorate("mate", gp.staticLimit(key=operator.attrgetter("height"), max_value=MAX_HEIGHT))
+    toolbox.decorate("mutate", gp.staticLimit(key=operator.attrgetter("height"), max_value=MAX_HEIGHT))
+    toolbox.decorate("mate", gp.staticLimit(key=len, max_value=MAX_NODES))
+    toolbox.decorate("mutate", gp.staticLimit(key=len, max_value=MAX_NODES))
     # [end-bloat-control]
 
     # [begin-bookkeeping]


### PR DESCRIPTION
### What

Make the bloat control values hyperparmeters 

### Why

It makes it more obvious that this is something that can be played with 

### Testing

:+1: 

### Additional Notes

~One may notice that, assuming binary trees, a depth of 6 would have a max nodes of 64, however the max nodes is set to 32. This is intentional since the uneven tree heights are fine.~ 

Actually, I'm not sure how DEAP counts height, so it may not matter. Either way, if they're not matching in terms of max nodes and height, it does not matter. 

