### PR TITLE
:technologist: Code --- ~Remove fstrings if not really fstrings~ Include more details in exceptions :microscope: 

### DIFF
--- a/src/ga_max_bitstring.py
+++ b/src/ga_max_bitstring.py
@@ -32,7 +32,7 @@ def value_fitness(chromosome: list) -> int:
     :raises ValueError: If the chromosome is empty
     """
     if len(chromosome) == 0:
-        raise ValueError("Empty chromosome cannot be evaluated")
+        raise ValueError(f"Empty chromosome cannot be evaluated: {chromosome}")
     return int("".join(str(bit) for bit in chromosome), 2)
 
 
@@ -45,7 +45,7 @@ def ones_fitness(chromosome: list) -> int:
     :raises ValueError: If the chromosome is empty
     """
     if len(chromosome) == 0:
-        raise ValueError("Empty chromosome cannot be evaluated")
+        raise ValueError(f"Empty chromosome cannot be evaluated: {chromosome}")
     number_of_ones = 0
     for bit in chromosome:
         number_of_ones += bit

--- a/src/ga_max_bitstring.py
+++ b/src/ga_max_bitstring.py
@@ -32,7 +32,7 @@ def value_fitness(chromosome: list) -> int:
     :raises ValueError: If the chromosome is empty
     """
     if len(chromosome) == 0:
-        raise ValueError(f"Empty chromosome cannot be evaluated")
+        raise ValueError("Empty chromosome cannot be evaluated")
     return int("".join(str(bit) for bit in chromosome), 2)
 
 
@@ -45,7 +45,7 @@ def ones_fitness(chromosome: list) -> int:
     :raises ValueError: If the chromosome is empty
     """
     if len(chromosome) == 0:
-        raise ValueError(f"Empty chromosome cannot be evaluated")
+        raise ValueError("Empty chromosome cannot be evaluated")
     number_of_ones = 0
     for bit in chromosome:
         number_of_ones += bit

--- a/src/selection.py
+++ b/src/selection.py
@@ -12,7 +12,7 @@ def roulette_wheel_selection(population: list, population_fitness: list, pill_la
     if pill_landing < 0 or pill_landing >= 1:
         raise ValueError(f"pill_landing must be between [0, 1): {pill_landing}")
     if sum(population_fitness) == 0:
-        raise ValueError("Total fitness of population is 0")
+        raise ValueError(f"Fitness cannot be zero: {sum(population_fitness)}")
     pill_landing_scaled = pill_landing * sum(population_fitness)
     cumulative_sum = [sum(population_fitness[: i + 1]) for i in range(len(population_fitness))]
     for i, candidate_probability_edge in enumerate(cumulative_sum):

--- a/src/selection.py
+++ b/src/selection.py
@@ -12,7 +12,7 @@ def roulette_wheel_selection(population: list, population_fitness: list, pill_la
     if pill_landing < 0 or pill_landing >= 1:
         raise ValueError(f"pill_landing must be between [0, 1): {pill_landing}")
     if sum(population_fitness) == 0:
-        raise ValueError(f"Total fitness of population is 0")
+        raise ValueError("Total fitness of population is 0")
     pill_landing_scaled = pill_landing * sum(population_fitness)
     cumulative_sum = [sum(population_fitness[: i + 1]) for i in range(len(population_fitness))]
     for i, candidate_probability_edge in enumerate(cumulative_sum):


### PR DESCRIPTION
### What

~Remove the use of f strings when there is no need for f string~
Add more details to the f strings for the exceptions. 

### Why
~ Mostly because my flake8 yelled at me~ It's better this way

### Testing

:+1: 

### Additional Notes

The messages are redundant to a silly level, but whatever, it's at least showing you that you were in fact wrong. E.g. 

`"Total fitness of population is 0"`
vs
`f"Total fitness of population is 0: {sum(population)}"`

Obv the sum will be 0, but still, it shows you. 