### PR TITLE
🆕 Assignments --- Warn about lying 🔬 

### DIFF
--- a/site/assignments/gp/gp.rst
+++ b/site/assignments/gp/gp.rst
@@ -6,6 +6,14 @@ Genetic Programming
 * **DUE**: Monday October 30, 2023 at 11:55pm; submitted on MOODLE.
 * **Files**: `Files available on the GitHub repository <https://github.com/jameshughes89/cs4XX-EvolutionaryComputation/tree/main/resources/regression-data>`_
 
+.. warning::
+
+    Claiming that objectives/tasks/enhancements were complete within the report when in reality they were not is a
+    (a) a serious form of academic misconduct --- falsifying results --- and (b) against the student code of conduct.
+
+    These violations are subject to severe penalty. All violations will be reported and investigated fully.
+
+
 
 Base Task
 =========

--- a/site/assignments/pso/pso.rst
+++ b/site/assignments/pso/pso.rst
@@ -5,6 +5,13 @@ Particle Swarm Optimization
 * **Maximum Points**: 30
 * **DUE**: Monday TBD, 2023 at 11:55pm; submitted on MOODLE.
 
+.. warning::
+
+    Claiming that objectives/tasks/enhancements were complete within the report when in reality they were not is a
+    (a) a serious form of academic misconduct --- falsifying results --- and (b) against the student code of conduct.
+
+    These violations are subject to severe penalty. All violations will be reported and investigated fully.
+
 
 
 Base Task

--- a/site/assignments/tsp/tsp.rst
+++ b/site/assignments/tsp/tsp.rst
@@ -6,6 +6,14 @@ Travelling Salesperson Problem
 * **DUE**: Monday October 9, 2023 at 11:55pm; submitted on MOODLE.
 * **Files**: `Files available on the GitHub repository <https://github.com/jameshughes89/cs4XX-EvolutionaryComputation/tree/main/resources/tsp>`_
 
+.. warning::
+
+    Claiming that objectives/tasks/enhancements were complete within the report when in reality they were not is a
+    (a) a serious form of academic misconduct --- falsifying results --- and (b) against the student code of conduct.
+
+    These violations are subject to severe penalty. All violations will be reported and investigated fully.
+
+
 
 Base Task
 =========

--- a/site/student-lectures/description.rst
+++ b/site/student-lectures/description.rst
@@ -92,6 +92,8 @@ as images or data files. **Note:** Keep the files small as large files may be re
     requests will not be accepted unless deemed acceptable by the instructor. This means that submitting a pull should
     be done sufficiently early that any required changes can be adequately addressed before the merging deadline.
 
+
+
 Provided Files
 ==============
 

--- a/site/student-projects/description.rst
+++ b/site/student-projects/description.rst
@@ -8,6 +8,13 @@ Project Description
 * **Presentation Date**: November 28th -- December 6th
 * **DUE**: Wednesday December 6th, 2023 at 11:55pm; submitted on MOODLE.
 
+.. warning::
+
+    Claiming that objectives/tasks/enhancements were complete within the report when in reality they were not is a
+    (a) a serious form of academic misconduct --- falsifying results --- and (b) against the student code of conduct.
+
+    These violations are subject to severe penalty. All violations will be reported and investigated fully.
+
 
 
 Base Task


### PR DESCRIPTION
### What

1. Warn about lying in the reports 
2. Sneak in some new lines

### Why

1. Given how the marking for the course is done, it's weird to me that they feel the need to lie. I'd say I'm surprised, but sadly I'm not though. 
2. Consistency 

### How

Add a warning to the top of assignments. 

### Testing

👎 

### Additional Notes

I'm not yet willing to throw trust out the window and changing how the course is done. That said, this is the first time I've had such an issue with senior undergraduates like this. 
