### PR TITLE
:mortar_board: Assignment GP --- New due date :microscope: 

### DIFF
--- a/site/assignments/gp/gp.rst
+++ b/site/assignments/gp/gp.rst
@@ -3,7 +3,13 @@ Genetic Programming
 *******************
 
 * **Maximum Points**: 30
-* **DUE**: Monday October 30, 2023 at 11:55pm; submitted on MOODLE.
+* **DUE**: **UPDATED** Monday November 6, 2023 at 11:55pm; submitted on MOODLE. 
+
+	* This is the Monday of reading week 
+	* Y'all asked for this 
+	* If the fact that it's reading week bothers you, then submit it before the original due date
+
+
 * **Files**: `Files available on the GitHub repository <https://github.com/jameshughes89/cs4XX-EvolutionaryComputation/tree/main/resources/regression-data>`_
 
 .. warning::


### PR DESCRIPTION
### What

Move the due date back 1 week. 


### Why

1. We only just started talking about GP, and although there's no reason they couldn't be working on it already, it's a valid point
2. They asked for a 1 week extension



### Additional Notes

1. The due date is now during reading week, and usually I avoid this, but they asked for this. 
2. The wording in the assignment description with respect to the new due date is defo a little silly, but it's carrying on the convo in the same tone from lecture.
3. They are senior students, so I have more trust in their requests. 