### PR TITLE
:bug: Index --- Fix links to student lectures :microscope: 

### DIFF
--- a/site/index.rst
+++ b/site/index.rst
@@ -78,8 +78,10 @@ YouTube
     student-lectures/description
     student-lectures/novelty-search/novelty-search
     student-lectures/cultural-algorithms/cultural-algorithms
-    student-lectures/memetic-algorithms/memetic-algorithms
+    student-lectures/Artificial-Life/artificial_life
+    student-lectures/Memetic-Algorithms/Memetic-Algorithms
     student-lectures/Differential_Evolution/Differential_Evolution
+
 
 .. toctree::
     :caption: Student Projects


### PR DESCRIPTION
### What

Fix links to student lectures (missing ones, lowercase/uppercase)

### Why

Broken

### Testing

:+1:  Build local, looks good 

### Additional Notes

I suspect some of the issues were caused by resolving conflicts. 