### PR TITLE
:mortar_board: Lectures/Projects/Assignment --- Update timelines 

### DIFF
--- a/site/assignments/pso/pso.rst
+++ b/site/assignments/pso/pso.rst
@@ -3,7 +3,7 @@ Particle Swarm Optimization
 ***************************
 
 * **Maximum Points**: 25
-* **DUE**: Monday November 25, 2024 at 11:55pm; submitted on MOODLE.
+* **DUE**: Monday December 2, 2024 at 11:55pm; submitted on MOODLE.
 
 .. warning::
 

--- a/site/student-lectures/description.rst
+++ b/site/student-lectures/description.rst
@@ -56,10 +56,10 @@ All topic choices along with preferred lecture date are to be submitted to the i
 
 Student Lecture Dates:
 
+
+* November 19 (2 slots available)
+* November 20 (2 slots available)
 * November 22 (2 slots available)
-* November 26 (2 slots available)
-* November 27 (2 slots available)
-* November 29 (2 slots available)
 
 
 

--- a/site/student-lectures/description.rst
+++ b/site/student-lectures/description.rst
@@ -34,12 +34,12 @@ topic choices along with preferred lecture date are to be submitted to the instr
 * Differential Evolution
 * Evolutionary Art --- TAKEN
 * Evolutionary Programming
-* Evolutionary Strategies --- TAKEN
+* Evolutionary Strategies
 * Fitness Predictors --- TAKEN
 * Grammatical Evolution
 * Learning Classifier Systems
 * Memetic Algorithms
-* Neuroevolution --- TAKEN
+* Neuroevolution
 * Novelty Search --- TAKEN
 * Search Space Analysis
 * Self Organization

--- a/site/student-projects/description.rst
+++ b/site/student-projects/description.rst
@@ -4,9 +4,9 @@ Project Description
 
 * **Maximum Points**: 30
 * **Topic Selection Due Date**: Friday November 8, 2024 at 11:55pm; submitted via email
-* **PR Merge Date**: If Applicable, At Least One Day Before the Lecture Date
+* **PR Merge Date**: If Applicable, At Least One Day Before the Presentation Date
 * **Presentation Date**: TBD
-* **DUE**: TBD, 2024 at 11:55pm; submitted on MOODLE.
+* **DUE**: December 6, 2024 at 11:55pm (accept until December 8 at 11:55pm with no penalty); submitted on MOODLE.
 
 .. warning::
 


### PR DESCRIPTION
### What

1. Update the topic list
2. Update the timeline for the lectures to be 1 week earlier and 1 day fewer
3. Update PSO assignment deadline to help with earlier project presentations
4. Set project deadline 

### Why

1. People dropped out 
2. More people want to do the project presentations, so I need to work that into the schedule. Further, apparently there is no lectures on the 3rd as the uni cancelled them for an event, and people will likely not show up to lecture on the 4th because of the event the night before, which means they certainly won't show up on the 6th for 1 presentation, the last day of class, (I think the uni messed up this year...) 
3. Given the earlier presentations, I am moving the deadline back
4. Needed to do this anyways

