### PR TITLE
Add flake8-pyproject to dependencies :microscope: 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "flake8==7.2.0",
   "flake8-black==0.3.6",
   "flake8-isort==6.1.2",
+  "flake8-pyproject==1.2.3",
   "isort==6.0.1",
   "matplotlib==3.10.3",
   "mdformat==0.7.22",


### PR DESCRIPTION
### What

Add flake8-pyproject to the dependencies 

### Why

Allows the flake8 settings to be put into the project.toml file

### Testing

Everything installed OK

### Additional Notes

Guess I never got the settings working like I thought? But... it was working... idk, whatever. It should be there. Maybe black did something. 